### PR TITLE
Decrypt SNS Topic used for SES "Bounce" notifications (to allow SES to send to it)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -196,8 +196,6 @@ resource "aws_iam_role_policy" "ses" {
 resource "aws_sns_topic" "ses_bounces" {
   count = var.create_bounce_topic ? 1 : 0
 
-  kms_master_key_id = "alias/aws/sns"
-
   display_name = coalesce(
     var.bounce_topic_name,
     "${local.email_domain} SES bounces"

--- a/main.tf
+++ b/main.tf
@@ -198,6 +198,10 @@ resource "aws_sns_topic" "ses_bounces" {
 
   kms_master_key_id = "alias/aws/sns"
 
+  display_name = coalesce(
+    var.bounce_topic_name,
+    "${local.email_domain} SES bounces"
+  )
   name = coalesce(
     var.bounce_topic_name,
     "${replace(local.email_domain, "/[^A-Za-z0-9-_]/", "-")}-ses-bounces"


### PR DESCRIPTION
[MA-1342](https://support.gtis.sil.org/issue/MA-1342)

---

### Fixed
- Decrypt SNS Topic used for SES "Bounce" notifications (to allow SES to send to it)

### Added
- Re-add display name 
  * That wasn't the problem preventing SES from using this SNS Topic.